### PR TITLE
Follow Go's commenting convetions

### DIFF
--- a/graph_client_factory.go
+++ b/graph_client_factory.go
@@ -6,11 +6,7 @@ import (
 	khttp "github.com/microsoft/kiota/http/go/nethttp"
 )
 
-// Creates a new default set of middlewares for the Graph Client
-// Parameters:
-// 		options - the options to use for the middlewares
-// Returns:
-// 		the middlewares
+// GetDefaultMiddlewaresWithOptions creates a default slice of middleware for the Graph Client.
 func GetDefaultMiddlewaresWithOptions(options *GraphClientOptions) []khttp.Middleware {
 	kiotaMiddlewares := khttp.GetDefaultMiddlewares()
 	graphMiddlewares := []khttp.Middleware{
@@ -24,12 +20,7 @@ func GetDefaultMiddlewaresWithOptions(options *GraphClientOptions) []khttp.Middl
 	return resultMiddlewares
 }
 
-// Create a new default net/http client with the options configured for the Graph Client
-// Parameters:
-// 		middleware - the middlewares to use for the client
-// 		options - the options to use for the middlewares
-// Returns:
-// 		the client
+// GetDefaultClient creates a new http client with a preconfigured middleware pipeline
 func GetDefaultClient(options *GraphClientOptions, middleware ...khttp.Middleware) *nethttp.Client {
 	if len(middleware) == 0 {
 		middleware = GetDefaultMiddlewaresWithOptions(options)

--- a/graph_client_options.go
+++ b/graph_client_options.go
@@ -1,9 +1,10 @@
 package msgraphgocore
 
-// Options for the GraphClient
+// GraphClientOptions represents a combination of GraphServiceVersion and GraphServiceLibraryVersion
+//
+// GraphServiceVersion is version of the targeted service.
+// GraphServiceLibraryVersion is the version of the service library
 type GraphClientOptions struct {
-	// The version of the targeted service for telemetry (v1.0, beta)
-	GraphServiceVersion string
-	// The version of the service library for telemetry (1.2.3)
+	GraphServiceVersion        string
 	GraphServiceLibraryVersion string
 }

--- a/graph_odata_query_handler.go
+++ b/graph_odata_query_handler.go
@@ -46,8 +46,6 @@ func NewGraphODataQueryHandler() *GraphODataQueryHandler {
 }
 
 // NewGraphODataQueryHandlerWithOptions creates a new instance of GraphODataQueryHandler
-// Parameters:
-// 		options: GraphODataQueryHandlerOptions options to use for the handler
 func NewGraphODataQueryHandlerWithOptions(options GraphODataQueryHandlerOptions) *GraphODataQueryHandler {
 	replacementRegexp := "(?i)([^$])(count|expand|filter|format|orderby|search|select|skip|skiptoken|top)="
 	return &GraphODataQueryHandler{

--- a/graph_request_adapter_base.go
+++ b/graph_request_adapter_base.go
@@ -15,47 +15,21 @@ type GraphRequestAdapterBase struct {
 }
 
 // NewGraphRequestAdapterBase creates a new GraphRequestAdapterBase with the given parameters
-// Parameters:
-// authenticationProvider: the provider used to authenticate requests
-// clientOptions: the options used to configure the client
-// Returns:
-// a new GraphRequestAdapterBase
 func NewGraphRequestAdapterBase(authenticationProvider absauth.AuthenticationProvider, clientOptions GraphClientOptions) (*GraphRequestAdapterBase, error) {
 	return NewGraphRequestAdapterBaseWithParseNodeFactory(authenticationProvider, clientOptions, nil)
 }
 
 // NewGraphRequestAdapterBaseWithParseNodeFactory creates a new GraphRequestAdapterBase with the given parameters
-// Parameters:
-// authenticationProvider: the provider used to authenticate requests
-// clientOptions: the options used to configure the client
-// parseNodeFactory: the factory used to create parse nodes
-// Returns:
-// a new GraphRequestAdapterBase
 func NewGraphRequestAdapterBaseWithParseNodeFactory(authenticationProvider absauth.AuthenticationProvider, clientOptions GraphClientOptions, parseNodeFactory absser.ParseNodeFactory) (*GraphRequestAdapterBase, error) {
 	return NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactory(authenticationProvider, clientOptions, parseNodeFactory, nil)
 }
 
 // NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactory creates a new GraphRequestAdapterBase with the given parameters
-// Parameters:
-// authenticationProvider: the provider used to authenticate requests
-// clientOptions: the options used to configure the client
-// parseNodeFactory: the factory used to create parse nodes
-// serializationWriterFactory: the factory used to create serialization writers
-// Returns:
-// a new GraphRequestAdapterBase
 func NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactory(authenticationProvider absauth.AuthenticationProvider, clientOptions GraphClientOptions, parseNodeFactory absser.ParseNodeFactory, serializationWriterFactory absser.SerializationWriterFactory) (*GraphRequestAdapterBase, error) {
 	return NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(authenticationProvider, clientOptions, parseNodeFactory, serializationWriterFactory, nil)
 }
 
 // NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient creates a new GraphRequestAdapterBase with the given parameters
-// Parameters:
-// authenticationProvider: the provider used to authenticate requests
-// clientOptions: the options used to configure the client
-// parseNodeFactory: the factory used to create parse nodes
-// serializationWriterFactory: the factory used to create serialization writers
-// httpClient: the client used to send requests
-// Returns:
-// a new GraphRequestAdapterBase
 func NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(authenticationProvider absauth.AuthenticationProvider, clientOptions GraphClientOptions, parseNodeFactory absser.ParseNodeFactory, serializationWriterFactory absser.SerializationWriterFactory, httpClient *nethttp.Client) (*GraphRequestAdapterBase, error) {
 	if authenticationProvider == nil {
 		return nil, errors.New("authenticationProvider cannot be nil")

--- a/graph_telemetry_handler.go
+++ b/graph_telemetry_handler.go
@@ -15,10 +15,6 @@ type GraphTelemetryHandler struct {
 }
 
 // NewGraphTelemetryHandler creates a new GraphTelemetryHandler.
-// Parameters:
-//   options - the options for the GraphClient.
-// Returns:
-//   the new GraphTelemetryHandler.
 func NewGraphTelemetryHandler(options *GraphClientOptions) *GraphTelemetryHandler {
 	serviceVersionPrefix := ""
 	if options != nil && options.GraphServiceLibraryVersion != "" {


### PR DESCRIPTION
## Overview
1. Follows Go commenting convention where comments didn't follow the convention
2. Removes parameters and return types because **go doc** prints the function signature together with the documentation.

## Demo
The snippet below shows the output of a go doc command. Note that the function signature is also printed followed by the comment description. 
```
package msgraphgocore // import "github.com/microsoftgraph/msgraph-sdk-go-core"

func GetDefaultClient(middleware ...khttp.Middleware) *nethttp.Client
    GetDefaultClient creates a new http client with a preconfigured middleware
    pipeline
```