### PR TITLE
add PR template and add @jobala to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @andrueastman @baywet @darrelmiller @zengin @MichaelMainer @ddyett @peombwa @nikithauc @ramsessanchez
+* @andrueastman @baywet @darrelmiller @zengin @MichaelMainer @ddyett @peombwa @nikithauc @ramsessanchez @jobala

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Overview
+
+Brief description of what this PR does
+
+## Demo
+Optional. Screenshots, examples, etc.
+
+## Notes
+Optional. Ancilliary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing
+* How to test this PR
+* Prefer bulleted description
+* Start after checking out this branch
+* Include any setup required, such as bundling scripts, restarting services, etc.
+* Include test case and expected output


### PR DESCRIPTION
## Overview
1. Adds a PR template
2. Adds @jobala to codeowners

## Notes
We have found the PR template helps with information sharing in the msgraph-cli and msgraph-sdk-python-core repos and hoping it would do the same for this repo.