### PR TITLE
Logging Handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Jetbrains files
 .idea/
+
+# kiota
+kiota/

--- a/logging_handler.go
+++ b/logging_handler.go
@@ -18,7 +18,7 @@ func NewLoggingHandler(clientTrace *httptrace.ClientTrace) *LoggingHandler {
 		trace: clientTrace,
 	}
 }
-up
+
 func (logger LoggingHandler) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *http.Request) (*http.Response, error) {
 	req = req.WithContext(httptrace.WithClientTrace(req.Context(), logger.trace))
 	return pipeline.Next(req, middlewareIndex)

--- a/logging_handler.go
+++ b/logging_handler.go
@@ -8,10 +8,12 @@ import (
 	khttp "github.com/microsoft/kiota/http/go/nethttp"
 )
 
+// LoggingHandler represents a middleware used to print logs about http requests
 type LoggingHandler struct {
 	trace *httptrace.ClientTrace
 }
 
+// NewLoggingHandler creates an instance of the logging handler middleware
 func NewLoggingHandler(clientTrace *httptrace.ClientTrace) *LoggingHandler {
 	return &LoggingHandler{
 		trace: clientTrace,

--- a/logging_handler.go
+++ b/logging_handler.go
@@ -1,0 +1,24 @@
+package msgraphgocore
+
+import (
+	"net/http"
+	nethttp "net/http"
+	"net/http/httptrace"
+
+	khttp "github.com/microsoft/kiota/http/go/nethttp"
+)
+
+type LoggingHandler struct {
+	trace *httptrace.ClientTrace
+}
+
+func NewLoggingHandler(clientTrace *httptrace.ClientTrace) *LoggingHandler {
+	return &LoggingHandler{
+		trace: clientTrace,
+	}
+}
+
+func (logger LoggingHandler) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request) (*http.Response, error) {
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), logger.trace))
+	return pipeline.Next(req, middlewareIndex)
+}

--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -1,0 +1,33 @@
+package msgraphgocore
+
+import (
+	"fmt"
+	"net/http"
+	httptest "net/http/httptest"
+	"net/http/httptrace"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceCallbacksGetCalled(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "hello world")
+	}))
+	defer testServer.Close()
+
+	gotConnWasCalled := false
+
+	trace := httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			gotConnWasCalled = true
+		},
+	}
+
+	logHandler := NewLoggingHandler(&trace)
+	client := GetDefaultClient(nil, logHandler)
+	client.Get("https://example.com")
+
+	assert.Equal(t, gotConnWasCalled, true)
+}


### PR DESCRIPTION
## Overview

Adds a logging handler

## Demo

```go
trace := httptrace.ClientTrace{
  GotConn: func(info httptrace.GotConnInfo) {
        // do something with the info
  },
}


logHandler := NewLoggingHandler(&trace)
client := GetDefaultClient(nil, logHandler)
client.Get("https://example.com")
```
## Notes
N/A

## Testing
* Create a ClientTrace object
* Create a logging handler with **NewLoggingHandler** and pass the ClientTrace object.
* Create a client with  core lib's **NewDefaultClient** and pass the logging handler
* Make a request and observe that the callback specified in the ClientTrace object gets called.

Closes #31 