### PR TITLE
- publishes a version retract for 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.0.14] - 2022-03-11
+
+### Changed
+
+- Publishes a version retraction for v0.11.0 that was wrongfully published and causes issues during upgrades
+
 ## [0.0.13] - 2022-03-04
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,10 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+retract (
+	v0.11.0
+	// error in version bump, bumped minor instead of patch, causing issues with update commands as long as we don't have a higher version number
+	v0.0.14
+	// contains retraction only
+)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package msgraphgocore
 
-var CoreVersion = "0.0.13"
+var CoreVersion = "0.0.14"


### PR DESCRIPTION
fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/101

additional documentation https://go.dev/ref/mod#go-mod-file-retract