### PR TITLE
Fixes pageIterator to use updated nextLink property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.27.0] - 2022-07-21
+
+### Changed
+
+- Fixes PageIterator to use updated nextLink property
+
+### Changed
+
 ## [0.26.2] - 2022-06-12
 
 ### Changed

--- a/internal/invalid_user_response.go
+++ b/internal/invalid_user_response.go
@@ -1,0 +1,133 @@
+package internal
+
+import (
+	i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55 "github.com/microsoft/kiota-abstractions-go/serialization"
+)
+
+// InvalidUsersResponse
+type InvalidUsersResponse struct {
+	// Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+	additionalData map[string]interface{}
+	//
+	nextLink *string
+	//
+	value []User
+}
+
+// NewInvalidUsersResponse instantiates a new InvalidUsersResponse and sets the default values.
+func NewInvalidUsersResponse() *InvalidUsersResponse {
+	m := &InvalidUsersResponse{}
+	m.SetAdditionalData(make(map[string]interface{}))
+	return m
+}
+
+// GetAdditionalData gets the additionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+func (m *InvalidUsersResponse) GetAdditionalData() map[string]interface{} {
+	if m == nil {
+		return nil
+	} else {
+		return m.additionalData
+	}
+}
+
+// GetNextLink gets the @odata.nextLink property value.
+func (m *InvalidUsersResponse) GetNextLink() *string {
+	if m == nil {
+		return nil
+	} else {
+		return m.nextLink
+	}
+}
+
+// GetValue gets the value property value.
+func (m *InvalidUsersResponse) GetValue() []User {
+	if m == nil {
+		return nil
+	} else {
+		return m.value
+	}
+}
+
+// GetFieldDeserializers the deserialization information for the current model
+func (m *InvalidUsersResponse) GetFieldDeserializers() map[string]func(i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error {
+	res := make(map[string]func(i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error)
+	res["@odata.nextLink"] = func(n i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error {
+		val, err := n.GetStringValue()
+		if err != nil {
+			return err
+		}
+		if val != nil {
+			m.SetNextLink(val)
+		}
+		return nil
+	}
+	res["value"] = func(n i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error {
+		val, err := n.GetCollectionOfObjectValues(func(pn i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) (i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.Parsable, error) {
+			return NewUser(), nil
+		})
+		if err != nil {
+			return err
+		}
+		if val != nil {
+			res := make([]User, len(val))
+			for i, v := range val {
+				res[i] = *(v.(*User))
+			}
+			m.SetValue(res)
+		}
+		return nil
+	}
+	return res
+}
+func (m *InvalidUsersResponse) IsNil() bool {
+	return m == nil
+}
+
+// Serialize serializes information the current object
+func (m *InvalidUsersResponse) Serialize(writer i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.SerializationWriter) error {
+	{
+		err := writer.WriteStringValue("@odata.nextLink", m.GetNextLink())
+		if err != nil {
+			return err
+		}
+	}
+	{
+		cast := make([]i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.Parsable, len(m.GetValue()))
+		for i, v := range m.GetValue() {
+			temp := v
+			cast[i] = i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.Parsable(&temp)
+		}
+		err := writer.WriteCollectionOfObjectValues("value", cast)
+		if err != nil {
+			return err
+		}
+	}
+	{
+		err := writer.WriteAdditionalData(m.GetAdditionalData())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetAdditionalData sets the additionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+func (m *InvalidUsersResponse) SetAdditionalData(value map[string]interface{}) {
+	if m != nil {
+		m.additionalData = value
+	}
+}
+
+// SetNextLink sets the @odata.nextLink property value.
+func (m *InvalidUsersResponse) SetNextLink(value *string) {
+	if m != nil {
+		m.nextLink = value
+	}
+}
+
+// SetValue sets the value property value.
+func (m *InvalidUsersResponse) SetValue(value []User) {
+	if m != nil {
+		m.value = value
+	}
+}

--- a/internal/invalid_user_response.go
+++ b/internal/invalid_user_response.go
@@ -1,9 +1,5 @@
 package internal
 
-import (
-	i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55 "github.com/microsoft/kiota-abstractions-go/serialization"
-)
-
 // InvalidUsersResponse
 type InvalidUsersResponse struct {
 	// Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
@@ -48,67 +44,8 @@ func (m *InvalidUsersResponse) GetValue() []User {
 	}
 }
 
-// GetFieldDeserializers the deserialization information for the current model
-func (m *InvalidUsersResponse) GetFieldDeserializers() map[string]func(i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error {
-	res := make(map[string]func(i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error)
-	res["@odata.nextLink"] = func(n i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error {
-		val, err := n.GetStringValue()
-		if err != nil {
-			return err
-		}
-		if val != nil {
-			m.SetNextLink(val)
-		}
-		return nil
-	}
-	res["value"] = func(n i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) error {
-		val, err := n.GetCollectionOfObjectValues(func(pn i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.ParseNode) (i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.Parsable, error) {
-			return NewUser(), nil
-		})
-		if err != nil {
-			return err
-		}
-		if val != nil {
-			res := make([]User, len(val))
-			for i, v := range val {
-				res[i] = *(v.(*User))
-			}
-			m.SetValue(res)
-		}
-		return nil
-	}
-	return res
-}
 func (m *InvalidUsersResponse) IsNil() bool {
 	return m == nil
-}
-
-// Serialize serializes information the current object
-func (m *InvalidUsersResponse) Serialize(writer i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.SerializationWriter) error {
-	{
-		err := writer.WriteStringValue("@odata.nextLink", m.GetNextLink())
-		if err != nil {
-			return err
-		}
-	}
-	{
-		cast := make([]i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.Parsable, len(m.GetValue()))
-		for i, v := range m.GetValue() {
-			temp := v
-			cast[i] = i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.Parsable(&temp)
-		}
-		err := writer.WriteCollectionOfObjectValues("value", cast)
-		if err != nil {
-			return err
-		}
-	}
-	{
-		err := writer.WriteAdditionalData(m.GetAdditionalData())
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SetAdditionalData sets the additionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.

--- a/internal/user_response.go
+++ b/internal/user_response.go
@@ -9,7 +9,7 @@ type UsersResponse struct {
 	// Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
 	additionalData map[string]interface{}
 	//
-	nextLink *string
+	odataNextLink *string
 	//
 	value []User
 }
@@ -30,12 +30,12 @@ func (m *UsersResponse) GetAdditionalData() map[string]interface{} {
 	}
 }
 
-// GetNextLink gets the @odata.nextLink property value.
-func (m *UsersResponse) GetNextLink() *string {
+// GetOdataNextLink gets the @odata.nextLink property value.
+func (m *UsersResponse) GetOdataNextLink() *string {
 	if m == nil {
 		return nil
 	} else {
-		return m.nextLink
+		return m.odataNextLink
 	}
 }
 
@@ -57,7 +57,7 @@ func (m *UsersResponse) GetFieldDeserializers() map[string]func(i04eb5309aeaafad
 			return err
 		}
 		if val != nil {
-			m.SetNextLink(val)
+			m.SetOdataNextLink(val)
 		}
 		return nil
 	}
@@ -86,7 +86,7 @@ func (m *UsersResponse) IsNil() bool {
 // Serialize serializes information the current object
 func (m *UsersResponse) Serialize(writer i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55.SerializationWriter) error {
 	{
-		err := writer.WriteStringValue("@odata.nextLink", m.GetNextLink())
+		err := writer.WriteStringValue("@odata.nextLink", m.GetOdataNextLink())
 		if err != nil {
 			return err
 		}
@@ -118,10 +118,10 @@ func (m *UsersResponse) SetAdditionalData(value map[string]interface{}) {
 	}
 }
 
-// SetNextLink sets the @odata.nextLink property value.
-func (m *UsersResponse) SetNextLink(value *string) {
+// SetOdataNextLink sets the @odata.nextLink property value.
+func (m *UsersResponse) SetOdataNextLink(value *string) {
 	if m != nil {
-		m.nextLink = value
+		m.odataNextLink = value
 	}
 }
 

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -200,7 +200,7 @@ func convertToPage(response interface{}) (PageResult, error) {
 	}
 	value = reflect.NewAt(value.Type(), unsafe.Pointer(value.UnsafeAddr())).Elem()
 
-	nextLink := ref.FieldByName("nextLink")
+	nextLink := ref.FieldByName("odataNextLink")
 	var link *string
 	if !nextLink.IsNil() {
 		nextLink = reflect.NewAt(nextLink.Type(), unsafe.Pointer(nextLink.UnsafeAddr())).Elem()

--- a/page_iterator_test.go
+++ b/page_iterator_test.go
@@ -48,6 +48,20 @@ func TestConstructorWithInvalidGraphResponse(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestConstructorWithInvalidUserGraphResponse(t *testing.T) {
+	graphResponse := internal.NewInvalidUsersResponse()
+
+	nextLink := "next-page"
+	users := make([]internal.User, 0)
+
+	graphResponse.SetNextLink(&nextLink)
+	graphResponse.SetValue(users)
+
+	_, err := NewPageIterator(graphResponse, reqAdapter, ParsableCons)
+
+	assert.NotNil(t, err)
+}
+
 func TestIterateStopsWhenCallbackReturnsFalse(t *testing.T) {
 	res := make([]string, 0)
 	graphResponse := buildGraphResponse()

--- a/page_iterator_test.go
+++ b/page_iterator_test.go
@@ -32,6 +32,14 @@ func ParsableCons(pn serialization.ParseNode) (serialization.Parsable, error) {
 	return internal.NewUsersResponse(), nil
 }
 
+func TestConstructorWithInvalidRequestAdapter(t *testing.T) {
+	graphResponse := internal.NewUsersResponse()
+
+	_, err := NewPageIterator(graphResponse, nil, ParsableCons)
+
+	assert.NotNil(t, err)
+}
+
 func TestConstructorWithInvalidGraphResponse(t *testing.T) {
 	graphResponse := internal.NewUsersResponse()
 
@@ -55,10 +63,11 @@ func TestIterateStopsWhenCallbackReturnsFalse(t *testing.T) {
 	        	]
         	}
         `)
-
+		assert.NotNil(t, req.Header["ConsistencyLevel"])
 	}))
 	defer testServer.Close()
 	pageIterator, _ := NewPageIterator(graphResponse, reqAdapter, ParsableCons)
+	pageIterator.SetHeaders(map[string]string{"ConsistencyLevel": "eventual"})
 
 	pageIterator.Iterate(func(pageItem interface{}) bool {
 		item := pageItem.(internal.User)

--- a/page_iterator_test.go
+++ b/page_iterator_test.go
@@ -89,7 +89,7 @@ func TestIterateEnumeratesAllPages(t *testing.T) {
 
 	graphResponse := buildGraphResponse()
 	mockPath := testServer.URL + "/next-page"
-	graphResponse.SetNextLink(&mockPath)
+	graphResponse.SetOdataNextLink(&mockPath)
 
 	pageIterator, _ := NewPageIterator(graphResponse, reqAdapter, ParsableCons)
 	res := make([]string, 0)
@@ -127,7 +127,7 @@ func TestIterateCanBePausedAndResumed(t *testing.T) {
 
 	response := buildGraphResponse()
 	mockPath := testServer.URL + "/next-page"
-	response.SetNextLink(&mockPath)
+	response.SetOdataNextLink(&mockPath)
 
 	pageIterator, _ := NewPageIterator(response, reqAdapter, ParsableCons)
 	pageIterator.Iterate(func(pageItem interface{}) bool {
@@ -162,7 +162,7 @@ func buildGraphResponse() *internal.UsersResponse {
 		users = append(users, *u)
 	}
 
-	res.SetNextLink(&nextLink)
+	res.SetOdataNextLink(&nextLink)
 	res.SetValue(users)
 
 	return res

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package msgraphgocore
 
-var CoreVersion = "0.26.2"
+var CoreVersion = "0.27.0"


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-go/issues/224

It fixes an issue where updated nextLink property of the collection models causes the pageIterator to fail. 

