### PR TITLE
update and fix breaking change with abstractions v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0] - 2022-08-24
+
+### Changed
+
+- Upgrade to library `kiota-abstraction` v1.0.0 breaking change
+
 ## [0.27.0] - 2022-07-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade to library `kiota-abstraction` v1.0.0 breaking change
+- Introduces `context.Context` object to Page Iterator
 
 ## [0.27.0] - 2022-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [1.0.0] - 2022-08-24
+## [0.28.0]- 2022-08-24
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/microsoft/kiota-abstractions-go v0.9.1
 	github.com/microsoft/kiota-http-go v0.7.0
-	github.com/microsoft/kiota-serialization-json-go v0.5.5
+	github.com/microsoft/kiota-serialization-json-go v0.5.6
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.18
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/microsoft/kiota-abstractions-go v0.8.2
-	github.com/microsoft/kiota-http-go v0.6.0
+	github.com/microsoft/kiota-abstractions-go v0.9.1
+	github.com/microsoft/kiota-http-go v0.7.0
 	github.com/microsoft/kiota-serialization-json-go v0.5.5
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/microsoft/kiota-abstractions-go v0.9.1 h1:22k/yIJVChq8TZyWT/X6RRUiVw1
 github.com/microsoft/kiota-abstractions-go v0.9.1/go.mod h1:i1wK2rdsLGSjgpnpLHjC60nEa/UdCVS6ulCh1Q+1COw=
 github.com/microsoft/kiota-http-go v0.7.0 h1:HO+er2JNGq3oM85WgIPIw89retOdIKHiMBZY+VcdyIo=
 github.com/microsoft/kiota-http-go v0.7.0/go.mod h1:96uLC2xNmlv8W3Jcv6j9EDtbXFbTzeNduo19MnF78F4=
-github.com/microsoft/kiota-serialization-json-go v0.5.5 h1:B0iKBKOdi+9NKFlormLRqduQ1+77MPGRsZ7xnd74EqQ=
-github.com/microsoft/kiota-serialization-json-go v0.5.5/go.mod h1:GI9vrssO1EvqzDtvMKuhjALn40phZOWkeeaMgtCk6xE=
+github.com/microsoft/kiota-serialization-json-go v0.5.6 h1:PfwdZF7aCMwujzJlCrb+OtS9OKX1KVdxxvnkgdPn3DE=
+github.com/microsoft/kiota-serialization-json-go v0.5.6/go.mod h1:tlzMdHUFVTtQdfmqRqf15542LMMFvXjGMEOiscGLjdk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -22,6 +22,5 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -5,10 +5,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/microsoft/kiota-abstractions-go v0.8.2 h1:KxHr72YwlntvVgF0C+8CtNmNQajtIq7fedq2N0+74Uk=
-github.com/microsoft/kiota-abstractions-go v0.8.2/go.mod h1:i1wK2rdsLGSjgpnpLHjC60nEa/UdCVS6ulCh1Q+1COw=
-github.com/microsoft/kiota-http-go v0.6.0 h1:pNdkRDLGBMuFryS5XvHUGzCsteAg2a4XMdsG8b7YQJs=
-github.com/microsoft/kiota-http-go v0.6.0/go.mod h1:4N7GGz5qCZ5JCsEpMyRmGecRckp2evUYRLetIvPBuYs=
+github.com/microsoft/kiota-abstractions-go v0.9.1 h1:22k/yIJVChq8TZyWT/X6RRUiVw1mLe44w60aYeukzKQ=
+github.com/microsoft/kiota-abstractions-go v0.9.1/go.mod h1:i1wK2rdsLGSjgpnpLHjC60nEa/UdCVS6ulCh1Q+1COw=
+github.com/microsoft/kiota-http-go v0.7.0 h1:HO+er2JNGq3oM85WgIPIw89retOdIKHiMBZY+VcdyIo=
+github.com/microsoft/kiota-http-go v0.7.0/go.mod h1:96uLC2xNmlv8W3Jcv6j9EDtbXFbTzeNduo19MnF78F4=
 github.com/microsoft/kiota-serialization-json-go v0.5.5 h1:B0iKBKOdi+9NKFlormLRqduQ1+77MPGRsZ7xnd74EqQ=
 github.com/microsoft/kiota-serialization-json-go v0.5.5/go.mod h1:GI9vrssO1EvqzDtvMKuhjALn40phZOWkeeaMgtCk6xE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -22,5 +22,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -149,7 +149,7 @@ func (pI *PageIterator) fetchNextPage(context context.Context) (serialization.Pa
 	requestInfo.Headers = pI.headers
 	requestInfo.AddRequestOptions(pI.reqOptions)
 
-	graphResponse, err = pI.reqAdapter.SendAsync(context, requestInfo, pI.constructorFunc, nil, nil)
+	graphResponse, err = pI.reqAdapter.SendAsync(context, requestInfo, pI.constructorFunc, nil)
 	if err != nil {
 		return graphResponse, errors.New("fetching next page failed")
 	}

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -73,12 +73,13 @@ func NewPageIterator(res interface{}, reqAdapter abstractions.RequestAdapter, co
 // return false from the callback.
 //
 // Example
-//      pageIterator, err := NewPageIterator(resp, reqAdapter, parsableFactory)
-//      callbackFunc := func (pageItem interface{}) bool {
-//          fmt.Println(page item.GetDisplayName())
-//          return true
-//      }
-//      err := pageIterator.Iterate(callbackFunc)
+//
+//	pageIterator, err := NewPageIterator(resp, reqAdapter, parsableFactory)
+//	callbackFunc := func (pageItem interface{}) bool {
+//	    fmt.Println(page item.GetDisplayName())
+//	    return true
+//	}
+//	err := pageIterator.Iterate(context.Background(), callbackFunc)
 func (pI *PageIterator) Iterate(context context.Context, callback func(pageItem interface{}) bool) error {
 	for {
 		keepIterating := pI.enumerate(callback)

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -1,6 +1,7 @@
 package msgraphgocore
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"reflect"
@@ -148,7 +149,7 @@ func (pI *PageIterator) fetchNextPage() (serialization.Parsable, error) {
 	requestInfo.Headers = pI.headers
 	requestInfo.AddRequestOptions(pI.reqOptions)
 
-	graphResponse, err = pI.reqAdapter.SendAsync(requestInfo, pI.constructorFunc, nil, nil)
+	graphResponse, err = pI.reqAdapter.SendAsync(context.Background(), requestInfo, pI.constructorFunc, nil, nil)
 	if err != nil {
 		return graphResponse, errors.New("fetching next page failed")
 	}

--- a/page_iterator_test.go
+++ b/page_iterator_test.go
@@ -1,6 +1,7 @@
 package msgraphgocore
 
 import (
+	"context"
 	"fmt"
 	nethttp "net/http"
 	httptest "net/http/httptest"
@@ -83,7 +84,7 @@ func TestIterateStopsWhenCallbackReturnsFalse(t *testing.T) {
 	pageIterator, _ := NewPageIterator(graphResponse, reqAdapter, ParsableCons)
 	pageIterator.SetHeaders(map[string]string{"ConsistencyLevel": "eventual"})
 
-	pageIterator.Iterate(func(pageItem interface{}) bool {
+	pageIterator.Iterate(context.Background(), func(pageItem interface{}) bool {
 		item := pageItem.(internal.User)
 
 		res = append(res, *item.GetDisplayName())
@@ -117,7 +118,7 @@ func TestIterateEnumeratesAllPages(t *testing.T) {
 	pageIterator, _ := NewPageIterator(graphResponse, reqAdapter, ParsableCons)
 	res := make([]string, 0)
 
-	err := pageIterator.Iterate(func(pageItem interface{}) bool {
+	err := pageIterator.Iterate(context.Background(), func(pageItem interface{}) bool {
 		item := pageItem.(internal.User)
 		res = append(res, *item.GetId())
 		return true
@@ -153,7 +154,7 @@ func TestIterateCanBePausedAndResumed(t *testing.T) {
 	response.SetOdataNextLink(&mockPath)
 
 	pageIterator, _ := NewPageIterator(response, reqAdapter, ParsableCons)
-	pageIterator.Iterate(func(pageItem interface{}) bool {
+	pageIterator.Iterate(context.Background(), func(pageItem interface{}) bool {
 		item := pageItem.(internal.User)
 		res = append(res, *item.GetId())
 
@@ -162,7 +163,7 @@ func TestIterateCanBePausedAndResumed(t *testing.T) {
 
 	assert.Equal(t, res, []string{"0", "1", "2", "3", "4"})
 
-	pageIterator.Iterate(func(pageItem interface{}) bool {
+	pageIterator.Iterate(context.Background(), func(pageItem interface{}) bool {
 		item := pageItem.(internal.User)
 		res2 = append(res2, *item.GetId())
 


### PR DESCRIPTION
## Overview

Fixes breaking changes introduces with version 1.0.0 [abstractions](https://github.com/microsoft/kiota-abstractions-go/pull/26).  


## Notes
SendAsync function in requestAdapter changed. All methods should be default use context.BackGround() or allow users to pass a context object

## Testing
* Compilating with v0.9.0 kiota-anstractions-go should be enough
* Unit tests available

Partially work on https://github.com/microsoftgraph/msgraph-sdk-go/issues/176