### PR TITLE
Adds generic helper methods for serialization and deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.29.0]- 2022-09-20
+
+### Added
+
+- Adds generic helper methods  `SetValue` , `SetObjectValue` and `SetCollectionValue` to reduce code duplication for serializer and deserializers
+
 ## [0.28.1]- 2022-09-09
 
 ### Changed

--- a/internal/person.go
+++ b/internal/person.go
@@ -1,0 +1,26 @@
+package internal
+
+type Person struct {
+	DisplayName *string
+	callRecord  *CallRecord
+}
+
+func NewPerson() *Person {
+	return &Person{}
+}
+
+type CallRecord struct {
+	Entity
+}
+
+func NewCallRecord() *CallRecord {
+	return &CallRecord{}
+}
+
+func (u *Person) SetCallRecord(record *CallRecord) {
+	u.callRecord = record
+}
+
+func (u *Person) GetCallRecord() *CallRecord {
+	return u.callRecord
+}

--- a/internal/person.go
+++ b/internal/person.go
@@ -1,9 +1,12 @@
 package internal
 
 type Person struct {
-	DisplayName *string
-	callRecord  *CallRecord
-	callRecords []*CallRecord
+	DisplayName    *string
+	callRecord     *CallRecord
+	callRecords    []*CallRecord
+	status         *PersonStatus
+	previousStatus []*PersonStatus
+	cardNumbers    []int
 }
 
 func NewPerson() *Person {
@@ -32,4 +35,28 @@ func (u *Person) SetCallRecords(records []*CallRecord) {
 
 func (u *Person) GetCallRecords() []*CallRecord {
 	return u.callRecords
+}
+
+func (u *Person) SetStatus(personStatus *PersonStatus) {
+	u.status = personStatus
+}
+
+func (u *Person) GetStatus() *PersonStatus {
+	return u.status
+}
+
+func (u *Person) SetPreviousStatus(previousStatus []*PersonStatus) {
+	u.previousStatus = previousStatus
+}
+
+func (u *Person) GetPreviousStatus() []*PersonStatus {
+	return u.previousStatus
+}
+
+func (u *Person) SetCardNumbers(numbers []int) {
+	u.cardNumbers = numbers
+}
+
+func (u *Person) GetCardNumbers() []int {
+	return u.cardNumbers
 }

--- a/internal/person.go
+++ b/internal/person.go
@@ -3,6 +3,7 @@ package internal
 type Person struct {
 	DisplayName *string
 	callRecord  *CallRecord
+	callRecords []*CallRecord
 }
 
 func NewPerson() *Person {
@@ -23,4 +24,12 @@ func (u *Person) SetCallRecord(record *CallRecord) {
 
 func (u *Person) GetCallRecord() *CallRecord {
 	return u.callRecord
+}
+
+func (u *Person) SetCallRecords(records []*CallRecord) {
+	u.callRecords = records
+}
+
+func (u *Person) GetCallRecords() []*CallRecord {
+	return u.callRecords
 }

--- a/internal/person.go
+++ b/internal/person.go
@@ -1,7 +1,7 @@
 package internal
 
 type Person struct {
-	DisplayName    *string
+	displayName    *string
 	callRecord     *CallRecord
 	callRecords    []*CallRecord
 	status         *PersonStatus
@@ -19,6 +19,13 @@ type CallRecord struct {
 
 func NewCallRecord() *CallRecord {
 	return &CallRecord{}
+}
+func (u *Person) SetDisplayName(name *string) {
+	u.displayName = name
+}
+
+func (u *Person) GetDisplayName() *string {
+	return u.displayName
 }
 
 func (u *Person) SetCallRecord(record *CallRecord) {

--- a/internal/person_status.go
+++ b/internal/person_status.go
@@ -1,0 +1,33 @@
+package internal
+
+import "errors"
+
+type PersonStatus int
+
+const (
+	ACTIVE PersonStatus = iota
+	SUSPEND
+)
+
+func (i PersonStatus) String() string {
+	return []string{"active", "suspended"}[i]
+}
+func ParsePersonStatus(v string) (interface{}, error) {
+	result := ACTIVE
+	switch v {
+	case "active":
+		result = ACTIVE
+	case "suspended":
+		result = SUSPEND
+	default:
+		return 0, errors.New("Unknown PersonStatus value: " + v)
+	}
+	return &result, nil
+}
+func SerializeTeamVisibilityType(values []PersonStatus) []string {
+	result := make([]string, len(values))
+	for i, v := range values {
+		result[i] = v.String()
+	}
+	return result
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,66 @@
+package msgraphgocore
+
+import "github.com/microsoft/kiota-abstractions-go/serialization"
+
+// SetValue receives a source function and applies the results to the setter
+//
+// source is any function that produces (*T, error)
+// setter recipient function of the result of the source if no error is produces
+func SetValue[T interface{}](source func() (*T, error), setter func(t *T)) error {
+	val, err := source()
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		setter(val)
+	}
+	return nil
+}
+
+// SetObjectValue takes a generic source with a discriminator receiver, reads value and writes it to a setter
+//
+// `source func() (*T, error)` is a generic getter with possible error response.
+// `setter func(t *T)` generic function that can write a value from the source
+func SetObjectValue[T interface{}](source func(ctor serialization.ParsableFactory) (serialization.Parsable, error), ctor serialization.ParsableFactory, setter func(t T)) error {
+	val, err := source(ctor)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := (val).(T)
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionValue is a utility function that receives a collection that can be cast to Parsable and a function that epects the results
+//
+// source is any function that receives a `ParsableFactory` and returns a slice of Parsable or error
+// ctor is a ParsableFactory
+// setter is a recipient of the function results
+func SetCollectionValue[T interface{}](source func(ctor serialization.ParsableFactory) ([]serialization.Parsable, error), ctor serialization.ParsableFactory, setter func(t []T)) error {
+	val, err := source(ctor)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]T, len(val))
+		for i, v := range val {
+			res[i] = v.(T)
+		}
+		setter(res)
+	}
+	return nil
+}
+
+// CollectionApply applies an operation to every element of the slice and returns a result of the modified collection
+//
+//  is a slice of all the elementents to be mutated
+// mutator applies an operation to the collection and returns a response of type `R`
+func CollectionApply[T any, R interface{}](collection []T, mutator func(t T) R) []R {
+	cast := make([]R, len(collection))
+	for i, v := range collection {
+		cast[i] = mutator(v)
+	}
+	return cast
+}

--- a/utils.go
+++ b/utils.go
@@ -162,3 +162,12 @@ func SetCollectionOfReferencedPrimitiveValue[T interface{}](source func(targetTy
 func Point[T interface{}](t T) *T {
 	return &t
 }
+
+func GetValueOrDefault[T interface{}](source func() *T, defaultValue T) T {
+	result := source()
+	if result != nil {
+		return *result
+	} else {
+		return defaultValue
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -158,3 +158,7 @@ func SetCollectionOfReferencedPrimitiveValue[T interface{}](source func(targetTy
 	}
 	return nil
 }
+
+func Point[T interface{}](t T) *T {
+	return &t
+}

--- a/utils.go
+++ b/utils.go
@@ -64,3 +64,97 @@ func CollectionApply[T any, R interface{}](collection []T, mutator func(t T) R) 
 	}
 	return cast
 }
+
+// SetEnumValue is a utility function that receives an enum getter , EnumFactory and applies the results to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetEnumValue[T interface{}](source func(parser serialization.EnumFactory) (interface{}, error), parser serialization.EnumFactory, setter func(t T)) error {
+	val, err := source(parser)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := (val).(T)
+		setter(res)
+	}
+	return nil
+}
+
+// SetReferencedEnumValue is a utility function that receives an enum getter , EnumFactory and applies a de-referenced result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetReferencedEnumValue[T interface{}](source func(parser serialization.EnumFactory) (interface{}, error), parser serialization.EnumFactory, setter func(t *T)) error {
+	val, err := source(parser)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := (val).(*T)
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionOfReferencedEnumValue is a utility function that receives an enum collection source , EnumFactory and applies a de-referenced result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetCollectionOfReferencedEnumValue[T interface{}](source func(parser serialization.EnumFactory) ([]interface{}, error), parser serialization.EnumFactory, setter func(t []*T)) error {
+	val, err := source(parser)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]*T, len(val))
+		for i, v := range val {
+			res[i] = (v).(*T)
+		}
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionOfPrimitiveValue is a utility function that receives a collection of primitives , targetType and applies the result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// targetType is a string representing the type of result
+// setter is a recipient of the function results
+func SetCollectionOfPrimitiveValue[T interface{}](source func(targetType string) ([]interface{}, error), targetType string, setter func(t []T)) error {
+	val, err := source(targetType)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]T, len(val))
+		for i, v := range val {
+			res[i] = v.(T)
+		}
+		setter(res)
+	}
+	return nil
+}
+
+// SetCollectionOfReferencedPrimitiveValue is a utility function that receives a collection of primitives , targetType and applies the re-referenced result of the factory to a setter
+//
+// source is any function that receives a `EnumFactory` and returns an interface or error
+// parser is an EnumFactory
+// setter is a recipient of the function results
+func SetCollectionOfReferencedPrimitiveValue[T interface{}](source func(targetType string) ([]interface{}, error), targetType string, setter func(t []T)) error {
+	val, err := source(targetType)
+	if err != nil {
+		return err
+	}
+	if val != nil {
+		res := make([]T, len(val))
+		for i, v := range val {
+			res[i] = *(v.(*T))
+		}
+		setter(res)
+	}
+	return nil
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -155,9 +155,8 @@ func TestSetCollectionOfReferencedEnumValueWithoutError(t *testing.T) {
 func TestSetCollectionOfReferencedEnumValueWithError(t *testing.T) {
 	person := internal.NewPerson()
 
-	slice := []interface{}{Point(internal.ACTIVE), Point(internal.SUSPEND)}
 	enumSource := func(parser serialization.EnumFactory) ([]interface{}, error) {
-		return slice, nil
+		return nil, errors.New("could not get from factory")
 	}
 
 	err := SetCollectionOfReferencedEnumValue(enumSource, internal.ParsePersonStatus, person.SetPreviousStatus)
@@ -165,7 +164,7 @@ func TestSetCollectionOfReferencedEnumValueWithError(t *testing.T) {
 	assert.Nil(t, person.GetPreviousStatus())
 }
 
-func TestSetSetCollectionOfPrimitiveValueWithoutError(t *testing.T) {
+func TestSetCollectionOfReferencedPrimitiveValueWithoutError(t *testing.T) {
 	person := internal.NewPerson()
 
 	slice := []interface{}{Point(1), Point(2), Point(3)}
@@ -180,7 +179,7 @@ func TestSetSetCollectionOfPrimitiveValueWithoutError(t *testing.T) {
 	assert.Equal(t, person.GetCardNumbers()[2], 3)
 }
 
-func TestSetSetCollectionOfPrimitiveValueWithError(t *testing.T) {
+func TestSetCollectionOfReferencedPrimitiveValueWithError(t *testing.T) {
 	person := internal.NewPerson()
 
 	dataSource := func(targetType string) ([]interface{}, error) {
@@ -188,6 +187,33 @@ func TestSetSetCollectionOfPrimitiveValueWithError(t *testing.T) {
 	}
 
 	err := SetCollectionOfReferencedPrimitiveValue(dataSource, "int", person.SetCardNumbers)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCardNumbers())
+}
+
+func TestSetCollectionOfPrimitiveValueWithoutError(t *testing.T) {
+	person := internal.NewPerson()
+
+	slice := []interface{}{1, 2, 3}
+	dataSource := func(targetType string) ([]interface{}, error) {
+		return slice, nil
+	}
+
+	err := SetCollectionOfPrimitiveValue(dataSource, "int", person.SetCardNumbers)
+	assert.Nil(t, err)
+	assert.Equal(t, person.GetCardNumbers()[0], 1)
+	assert.Equal(t, person.GetCardNumbers()[1], 2)
+	assert.Equal(t, person.GetCardNumbers()[2], 3)
+}
+
+func TestSetCollectionOfPrimitiveValueWithError(t *testing.T) {
+	person := internal.NewPerson()
+
+	dataSource := func(targetType string) ([]interface{}, error) {
+		return nil, errors.New("could not get from factory")
+	}
+
+	err := SetCollectionOfPrimitiveValue(dataSource, "int", person.SetCardNumbers)
 	assert.NotNil(t, err)
 	assert.Nil(t, person.GetCardNumbers())
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,32 @@
+package msgraphgocore
+
+import (
+	"errors"
+	"github.com/microsoftgraph/msgraph-sdk-go-core/internal"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSetValueWithoutError(t *testing.T) {
+
+	person := internal.NewPerson()
+	callFactory := func() (*internal.CallRecord, error) {
+		return internal.NewCallRecord(), nil
+	}
+
+	err := SetValue(callFactory, person.SetCallRecord)
+	assert.Nil(t, err)
+	assert.NotNil(t, person.GetCallRecord())
+}
+
+func TestSetValueWithError(t *testing.T) {
+
+	person := internal.NewPerson()
+	callFactory := func() (*internal.CallRecord, error) {
+		return nil, errors.New("could not get from factory")
+	}
+
+	err := SetValue(callFactory, person.SetCallRecord)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCallRecord())
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,8 +2,10 @@ package msgraphgocore
 
 import (
 	"errors"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
 	"github.com/microsoftgraph/msgraph-sdk-go-core/internal"
 	"github.com/stretchr/testify/assert"
+	"strconv"
 	"testing"
 )
 
@@ -29,4 +31,45 @@ func TestSetValueWithError(t *testing.T) {
 	err := SetValue(callFactory, person.SetCallRecord)
 	assert.NotNil(t, err)
 	assert.Nil(t, person.GetCallRecord())
+}
+
+func createCallRecordNode(parseNode serialization.ParseNode) (serialization.Parsable, error) {
+	return internal.NewCallRecord(), nil
+}
+
+func getObjectValue(ctor serialization.ParsableFactory) (serialization.Parsable, error) {
+	return internal.NewCallRecord(), nil
+}
+
+func TestSetObjectValueWithoutError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetObjectValue(getObjectValue, createCallRecordNode, person.SetCallRecord)
+	assert.Nil(t, err)
+	assert.NotNil(t, person.GetCallRecord())
+}
+
+func getObjectsValues(ctor serialization.ParsableFactory) ([]serialization.Parsable, error) {
+	slice := []serialization.Parsable{internal.NewCallRecord(), internal.NewCallRecord(), internal.NewCallRecord()}
+	return slice, nil
+}
+
+func TestSetCollectionValueValueWithoutError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetCollectionValue(getObjectsValues, createCallRecordNode, person.SetCallRecords)
+	assert.Nil(t, err)
+	assert.Equal(t, len(person.GetCallRecords()), 3)
+}
+
+func TestCollectionApply(t *testing.T) {
+
+	slice := []string{"1", "2", "3"}
+	response := CollectionApply(slice, func(s string) int {
+		i, _ := strconv.Atoi(s)
+		return i
+	})
+
+	assert.Equal(t, len(response), 3)
+	assert.Equal(t, response, []int{1, 2, 3})
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -133,7 +133,7 @@ func TestSetReferencedEnumValueValueValueWithoutError(t *testing.T) {
 
 func TestSetReferencedEnumValueValueValueWithError(t *testing.T) {
 	person := internal.NewPerson()
-	err := SetEnumValue(getEnumValueWithError, internal.ParsePersonStatus, person.SetStatus)
+	err := SetReferencedEnumValue(getEnumValueWithError, internal.ParsePersonStatus, person.SetStatus)
 	assert.NotNil(t, err)
 	assert.Nil(t, person.GetStatus())
 }
@@ -203,6 +203,7 @@ func TestSetCollectionOfPrimitiveValueWithoutError(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, person.GetCardNumbers()[0], 1)
 	assert.Equal(t, person.GetCardNumbers()[1], 2)
+	assert.Equal(t, person.GetCardNumbers()[1], 2)
 	assert.Equal(t, person.GetCardNumbers()[2], 3)
 }
 
@@ -216,4 +217,13 @@ func TestSetCollectionOfPrimitiveValueWithError(t *testing.T) {
 	err := SetCollectionOfPrimitiveValue(dataSource, "int", person.SetCardNumbers)
 	assert.NotNil(t, err)
 	assert.Nil(t, person.GetCardNumbers())
+}
+
+func TestGetValueReturn(t *testing.T) {
+	person := internal.NewPerson()
+
+	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Unknown")
+
+	person.SetDisplayName(Point("Jane"))
+	assert.Equal(t, GetValueOrDefault(person.GetDisplayName, "Unknown"), "Jane")
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -41,6 +41,10 @@ func getObjectValue(ctor serialization.ParsableFactory) (serialization.Parsable,
 	return internal.NewCallRecord(), nil
 }
 
+func getObjectValueWithError(ctor serialization.ParsableFactory) (serialization.Parsable, error) {
+	return nil, errors.New("could not get from factory")
+}
+
 func TestSetObjectValueWithoutError(t *testing.T) {
 
 	person := internal.NewPerson()
@@ -49,9 +53,22 @@ func TestSetObjectValueWithoutError(t *testing.T) {
 	assert.NotNil(t, person.GetCallRecord())
 }
 
+func TestSetObjectValueWithError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetObjectValue(getObjectValueWithError, createCallRecordNode, person.SetCallRecord)
+
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCallRecord())
+}
+
 func getObjectsValues(ctor serialization.ParsableFactory) ([]serialization.Parsable, error) {
 	slice := []serialization.Parsable{internal.NewCallRecord(), internal.NewCallRecord(), internal.NewCallRecord()}
 	return slice, nil
+}
+
+func getObjectsValuesWithError(ctor serialization.ParsableFactory) ([]serialization.Parsable, error) {
+	return nil, errors.New("could not get from factory")
 }
 
 func TestSetCollectionValueValueWithoutError(t *testing.T) {
@@ -59,7 +76,17 @@ func TestSetCollectionValueValueWithoutError(t *testing.T) {
 	person := internal.NewPerson()
 	err := SetCollectionValue(getObjectsValues, createCallRecordNode, person.SetCallRecords)
 	assert.Nil(t, err)
+	assert.NotNil(t, person.GetCallRecords())
 	assert.Equal(t, len(person.GetCallRecords()), 3)
+}
+
+func TestSetCollectionValueValueWithError(t *testing.T) {
+
+	person := internal.NewPerson()
+	err := SetCollectionValue(getObjectsValuesWithError, createCallRecordNode, person.SetCallRecords)
+	assert.NotNil(t, err)
+	assert.Nil(t, person.GetCallRecords())
+	assert.Equal(t, len(person.GetCallRecords()), 0)
 }
 
 func TestCollectionApply(t *testing.T) {


### PR DESCRIPTION
## Overview

Partially address https://github.com/microsoft/kiota/issues/1404

Adds generic helper methods for serializers and deserializers

## Demo

SetValue 
Current 

```go
    res["proof"] = func (n i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
        val, err := n.GetStringValue()
        if err != nil {
            return err
        }
        if val != nil {
            m.SetProof(val)
        }
        return nil
    }
```
Is transformed to 
```go
	res["proof"] = func(n serialization.ParseNode) error {
		return msgraphsdkgo.SetValue(n.GetStringValue, m.SetProof)
	}
}
```

SetObjectValue

Current 
```go
    res["passwordCredential"] = func (n serialization.ParseNode) error {
        val, err := n.GetObjectValue(iadcd81124412c61e647227ecfc4449d8bba17de0380ddda76f641a29edf2b242.CreatePasswordCredentialFromDiscriminatorValue)
        if err != nil {
            return err
        }
        if val != nil {
            m.SetPasswordCredential(val.(iadcd81124412c61e647227ecfc4449d8bba17de0380ddda76f641a29edf2b242.PasswordCredentialable))
        }
        return nil
    }
```

Final
```go
	res["passwordCredential"] = func(n serialization.ParseNode) error {
		return msgraphsdkgo.SetObjectValue(n.GetObjectValue, iadcd81124412c61e647227ecfc4449d8bba17de0380ddda76f641a29edf2b242.CreatePasswordCredentialFromDiscriminatorValue, m.SetPasswordCredential)
	}
```

SetCollectionValue
From
```go
	res["value"] = func(n serialization.ParseNode) error {
		val, err := n.GetCollectionOfObjectValues(CreatePinnedChatMessageInfoFromDiscriminatorValue)
		if err != nil {
			return err
		}
		if val != nil {
			res := make([]PinnedChatMessageInfoable, len(val))
			for i, v := range val {
				res[i] = v.(PinnedChatMessageInfoable)
			}
			m.SetValue(res)
		}
		return nil
	}
```

To
```go
	res["value"] = func(n serialization.ParseNode) error {
		return msgraphsdkgo.SetCollectionValue[PinnedChatMessageInfoable](n.GetCollectionOfObjectValues, CreatePinnedChatMessageInfoFromDiscriminatorValue, m.SetValue)
	}
```

Collection Apply

From
```go
        cast := make([]i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable, len(m.GetValue()))
        for i, v := range m.GetValue() {
            cast[i] = v.(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable)
        }
```

To
```go
		cast := msgraphsdkgo.CollectionApply(m.GetValue(), func(v PinnedChatMessageInfoable) i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable {
			return v.(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable)
		})
```