### PR TITLE
Fix error swallowing in page iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.30.1] - 2022-10-21
+
+### Changed
+
+- Fix: Remove error swallowing in page iterator `fetchNextPage`.
+
 ## [0.30.0] - 2022-09-29
 
 ### Added

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -141,7 +141,7 @@ func (pI *PageIterator) fetchNextPage(context context.Context) (serialization.Pa
 
 	nextLink, err := url.Parse(*pI.currentPage.getOdataNextLink())
 	if err != nil {
-		return nil, err
+		return nil, errors.New("parsing nextLink url failed")
 	}
 
 	requestInfo := abstractions.NewRequestInformation()

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -141,7 +141,7 @@ func (pI *PageIterator) fetchNextPage(context context.Context) (serialization.Pa
 
 	nextLink, err := url.Parse(*pI.currentPage.getOdataNextLink())
 	if err != nil {
-		return graphResponse, errors.New("parsing nextLink url failed")
+		return nil, err
 	}
 
 	requestInfo := abstractions.NewRequestInformation()
@@ -152,7 +152,7 @@ func (pI *PageIterator) fetchNextPage(context context.Context) (serialization.Pa
 
 	graphResponse, err = pI.reqAdapter.SendAsync(context, requestInfo, pI.constructorFunc, nil)
 	if err != nil {
-		return graphResponse, errors.New("fetching next page failed")
+		return nil, err
 	}
 
 	return graphResponse, nil


### PR DESCRIPTION
## Overview
Resolves Comment https://github.com/microsoftgraph/msgraph-sdk-go/issues/302#issuecomment-1286026353

Currently Page Iterator does not propagate the internal error that happened and instead replaces the error. This fix should allow reporting the actual error that occurred and remove error swallowing


