### PR TITLE
Invoke page iterator by method not field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.34.1] - 2023-03-06
+
+### Changed
+
+- Change `PageIterator` to use `GetValue` method instead of `value` field to access response.
+
 ## [0.34.0] - 2023-02-23
 
 ### Added

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -3,12 +3,10 @@ package msgraphgocore
 import (
 	"context"
 	"errors"
-	"net/url"
-	"reflect"
-	"unsafe"
-
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
+	"net/url"
+	"reflect"
 )
 
 // PageIterator represents an iterator object that can be used to get subsequent pages of a collection.
@@ -199,13 +197,12 @@ func convertToPage(response interface{}) (PageResult, error) {
 	if response == nil {
 		return page, errors.New("response cannot be nil")
 	}
-	ref := reflect.ValueOf(response).Elem()
 
-	value := ref.FieldByName("value")
-	if value.IsNil() {
+	method := reflect.ValueOf(response).MethodByName("GetValue")
+	if method.IsNil() {
 		return page, errors.New("value property missing in response object")
 	}
-	value = reflect.NewAt(value.Type(), unsafe.Pointer(value.UnsafeAddr())).Elem()
+	value := method.Call(nil)[0]
 
 	// Collect all entities in the value slice.
 	// This converts a graph slice ie []graph.User to a dynamic slice []interface{}

--- a/page_iterator_test.go
+++ b/page_iterator_test.go
@@ -42,7 +42,7 @@ func TestConstructorWithInvalidRequestAdapter(t *testing.T) {
 }
 
 func TestConstructorWithInvalidGraphResponse(t *testing.T) {
-	graphResponse := internal.NewUsersResponse()
+	graphResponse := internal.NewInvalidUsersResponse()
 
 	_, err := NewPageIterator(graphResponse, reqAdapter, ParsableCons)
 


### PR DESCRIPTION
Changes invocation of page Iterator response to use MethodName instead of 'value`

This fixes iteration for Parsable values in a backing store

Resolves https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/166