### PR TITLE
Adds return type cast for page iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.35.0] - 2023-03-23
+
+### Added
+
+- `PageIterator` uses generics to define return type.
+
 ## [0.34.1] - 2023-03-06
 
 ### Changed


### PR DESCRIPTION
Adds a type parameter to page iterator. This will allows users to define return time for the iterator function and avoid a second step to cast the return type.

Partially address https://github.com/microsoftgraph/msgraph-sdk-go/issues/433

e.g
```go
NewPageIterator[models.Userable](response, reqAdapter, ParsableCons)
pageIterator.Iterate(context.Background(), func(item models.Userable) bool {  // <- Enforces types for the iterator func
		... left out for brevity
	})
```