### PR TITLE
Fixes BatchRequest URLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.36.1] - 2023-04-13
+
+### Added
+
+- Sets default `UrlReplacementPairs` on the Request adapter. Fixes batch requests urls for replaced Urls.
+
 ## [0.36.0] - 2023-03-27
 
 ### Added

--- a/batch_requests.go
+++ b/batch_requests.go
@@ -125,7 +125,7 @@ func (br *batchRequest) toBatchItem(requestInfo abstractions.RequestInformation)
 		requestInfo.PathParameters["baseurl"] = br.adapter.GetBaseUrl()
 	}
 
-	uri, err := requestInfo.GetUri()
+	uri, err := requestInfo.GetReplacedUri(br.adapter.GetUrlReplacementPairs())
 	if err != nil {
 		return nil, err
 	}

--- a/graph_client_factory.go
+++ b/graph_client_factory.go
@@ -1,9 +1,8 @@
 package msgraphgocore
 
 import (
-	nethttp "net/http"
-
 	khttp "github.com/microsoft/kiota-http-go"
+	nethttp "net/http"
 )
 
 // GetDefaultMiddlewaresWithOptions creates a default slice of middleware for the Graph Client.
@@ -11,7 +10,6 @@ func GetDefaultMiddlewaresWithOptions(options *GraphClientOptions) []khttp.Middl
 	kiotaMiddlewares := khttp.GetDefaultMiddlewares()
 	graphMiddlewares := []khttp.Middleware{
 		NewGraphTelemetryHandler(options),
-		khttp.NewUrlReplaceHandler(),
 	}
 	graphMiddlewaresLen := len(graphMiddlewares)
 	resultMiddlewares := make([]khttp.Middleware, len(kiotaMiddlewares)+graphMiddlewaresLen)

--- a/graph_request_adapter_base.go
+++ b/graph_request_adapter_base.go
@@ -44,6 +44,7 @@ func NewGraphRequestAdapterBaseWithParseNodeFactoryAndSerializationWriterFactory
 		parseNodeFactory = absser.DefaultParseNodeFactoryInstance
 	}
 	baseAdapter, err := khttp.NewNetHttpRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(authenticationProvider, parseNodeFactory, serializationWriterFactory, httpClient)
+	baseAdapter.SetUrlReplacementPairs(map[string]string{"/users/me-token-to-replace": "/me"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Overview

Resolved https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/179

Fixes issues on BatchRequests where request urls were not replaced by the token values. Depends on https://github.com/microsoft/kiota-abstractions-go/pull/77 and https://github.com/microsoft/kiota-http-go/pull/78 that moves replacement logic from RequestOptions to adapter
