### PR TITLE
Add 'HasNext', 'Next', and 'All' methods to PageIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.1] - 2023-09-15
+
+### Added
+
+- Adds `HasNext`, `Next`, and `All` methods to `PageIterator`.
+
 ## [1.0.0] - 2023-05-04
 
 ### Changed

--- a/page_iterator.go
+++ b/page_iterator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/url"
 	"reflect"
+	"strings"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
@@ -173,7 +174,7 @@ func (pI *PageIterator[T]) GetOdataDeltaLink() *string {
 // HasNext returns true if there are additional items to iterate.
 func (pI *PageIterator[T]) HasNext() bool {
 	return pI.pauseIndex < len(pI.currentPage.getValue()) ||
-		pI.GetOdataNextLink() != nil && *pI.GetOdataNextLink() != ""
+		pI.GetOdataNextLink() != nil && strings.TrimSpace(*pI.GetOdataNextLink()) != ""
 }
 
 func (pI *PageIterator[T]) fetchNextPage(context context.Context) (serialization.Parsable, error) {


### PR DESCRIPTION
## Overview

Adds `HasNext`, `Next`, and `All` methods to `PageIterator`. These methods allow iteration without callbacks. 

## Testing

Unit tests included.
