### PR TITLE
method.IsNil() panics and the actual error is never returned

### DIFF
--- a/page_iterator.go
+++ b/page_iterator.go
@@ -216,7 +216,7 @@ func convertToPage[T interface{}](response interface{}) (PageResult[T], error) {
 	}
 
 	method := reflect.ValueOf(response).MethodByName("GetValue")
-	if method.IsNil() {
+	if method.Kind() == reflect.Invalid {
 		return page, errors.New("value property missing in response object")
 	}
 	value := method.Call(nil)[0]


### PR DESCRIPTION
## Overview

Generic `func convertToPage[T interface{}](response interface{}) (PageResult[T], error)` 
method  uses `IsNil()` method from `reflect` package eg: `method.IsNil()` to check if the `response` argument is `Nil` and as a result it **`panics`** and the `actual`/`intended` error is never returned.
The PR addresses the panic, by replacing `method.IsNil()` check with `method.Kind() == reflect.Invalid` 