### PR TITLE
Fix GetBatchResponseById can't deserialization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.2] - 2023-12-01
+
+### Changed
+
+- Fixed a bug where GetBatchResponseById failed to deserialize error response bodies.
+
 ## [1.0.1] - 2023-11-24
 
 ### Changed

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -15,8 +15,21 @@ func (s SampleError) Serialize(writer serialization.SerializationWriter) error {
 	return nil
 }
 
-func (s SampleError) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
-	return make(map[string]func(serialization.ParseNode) error)
+func (s *SampleError) GetFieldDeserializers() map[string]func(serialization.ParseNode) error {
+	res := make(map[string]func(serialization.ParseNode) error)
+	res["error"] = func(n serialization.ParseNode) error {
+		v, err := n.GetRawValue()
+		if err != nil {
+			return err
+		}
+		if vm, ok := v.(map[string]interface{}); ok {
+			if msg, ok := vm["message"]; ok && msg != nil {
+				s.Message = *msg.(*string)
+			}
+		}
+		return nil
+	}
+	return res
 }
 
 func CreateSampleErrorFromDiscriminatorValue(parseNode serialization.ParseNode) (serialization.Parsable, error) {


### PR DESCRIPTION
## Overview

Fixes https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/247 
Fixes https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/248. 

`GetBatchResponseById` will now properly deserialize JSON encoded error bodies.


