### PR TITLE
Fix exit condition for page iterator

### DIFF
--- a/page_iterator.go
+++ b/page_iterator.go
@@ -177,7 +177,7 @@ func (pI *PageIterator[T]) enumerate(callback func(item T) bool) bool {
 	}
 
 	// the current page has no items to enumerate
-	if pI.currentPage.getValue() == nil {
+	if len(pI.currentPage.getValue()) == 0 {
 		return false
 	}
 


### PR DESCRIPTION
## Overview

Modify the page iterator to exit if there are no elements in the response of current API call.

## Demo
Optional. Screenshots, examples, etc.

## Notes
Optional. Ancilliary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing
* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case and expected output
