### PR TITLE
Corrected application/octet-stream typo

### DIFF
--- a/fileuploader/upload_slice.go
+++ b/fileuploader/upload_slice.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const binaryContentType = "application/octet-steam"
+const binaryContentType = "application/octet-stream"
 
 const uriLocationHeader = "Location"
 


### PR DESCRIPTION
There was a typo in the Content-Type header value, this corrects it.