### PR TITLE
fix: repeated slice uploading on large file upload task

### DIFF
--- a/authentication/azure_identity_access_token_provider.go
+++ b/authentication/azure_identity_access_token_provider.go
@@ -31,7 +31,7 @@ func NewAzureIdentityAccessTokenProviderWithScopesAndValidHostsAndObservabilityO
 	if err != nil {
 		return nil, err
 	}
-	if len(scopes) == 0 {
+	if len(validHosts) == 0 {
 		base.GetAllowedHostsValidator().SetAllowedHosts([]string{"graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn", "canary.graph.microsoft.com"})
 	}
 	result := &AzureIdentityAccessTokenProvider{

--- a/fileuploader/large_file_upload_task.go
+++ b/fileuploader/large_file_upload_task.go
@@ -3,13 +3,14 @@ package fileuploader
 import (
 	"context"
 	"errors"
-	abstractions "github.com/microsoft/kiota-abstractions-go"
-	"github.com/microsoft/kiota-abstractions-go/serialization"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
 )
 
 type LargeFileUploadTask[T serialization.Parsable] interface {
@@ -140,6 +141,8 @@ func (l *largeFileUploadTask[T]) uploadWithRetry(slice uploadSlice[T], maxRetry 
 			}
 			// backoff before retrying
 			time.Sleep(time.Duration(retry) * time.Second)
+		} else {
+			return parseable, location, err // return the result as the upload was successful
 		}
 		retry++
 	}


### PR DESCRIPTION
The `uploadWithRetry` does not check for that error/status but always attempts to upload the slice again even in success. Failing to do so may result in a conflict with the API.

This PR fixes the function to simply return in the event the chuck upload is successful. 

Related to https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/320