### PR TITLE
fix: Fix BatchItem deserialization for non-string primitive values

### DIFF
--- a/batch_item_model.go
+++ b/batch_item_model.go
@@ -277,13 +277,7 @@ func deserializeNodes(value []*jsonserialization.JsonParseNode) (interface{}, er
 
 func deserializeValue(value interface{}) (interface{}, error) {
 	switch v := value.(type) {
-	case int:
-	case float64:
-	case string:
-		return value, nil
-	case *int:
-	case *float64:
-	case *string:
+	case int, float64, string, *int, *float64, *string:
 		return value, nil
 	case jsonserialization.JsonParseNode:
 	case *jsonserialization.JsonParseNode:


### PR DESCRIPTION
## Overview
At this moment, when making any BatchRequests, the any primitive value in the results that are not strings are not being properly deserialized. That is because the case grouping was not done properly, and it skips all possible returns inside the switch block, falling into the `return nil, nil` loc.  This simple change fixes this by properly collapsing these options into a single case, separate by commas.

## Testing
* To replicate my original scenario, I did find this issue by batching mutiple `client.Drives().ByDriveId(driveID).Items().ByDriveItemId(fileID)` in a single batch
* When selecting any non-string values, like size in my case, these values were returned `nil`
* With this change, they return with their expected type

You can use the following snippet to replicate this test. If everything goes as expected, it should not panic at all
```go
requestConfig := &msgraph_drives.ItemItemsDriveItemItemRequestBuilderGetRequestConfiguration{
	QueryParameters: &msgraph_drives.ItemItemsDriveItemItemRequestBuilderGetQueryParameters{
		Select: ["size"], // anything else, but this was my main issue
	},
}

driveItemIds := []string{} // just add a driveItemId for any non-empty file in OneDrive/Sharepoint
driveItemIdToStepId := make(map[string]*string, len(driveItemIds))

for _, driveItemId := range driveItemIds {
	reqInfo, err := client.Drives().ByDriveId(driveID).Items().ByDriveItemId(driveItemId).ToGetRequestInformation(ctx, requestConfig)
	if err != nil {
		panic(err)
	}

	step, err := batchCollection.AddBatchRequestStep(*reqInfo)
	if err != nil {
		panic(err)
	}

	driveItemIdToStepId[driveItemId] = step.GetId()
}

batchResponse, err := batchCollection.Send(ctx, client.GetAdapter())
if err != nil {
	panic(err)
}

for _, driveItemId := range driveItemIds {
    stepID := driveItemIdToStepId[driveItemId]
    driveItem, err := msgraphcore.GetBatchResponseById[models.DriveItemable](
        batchResponse, *stepID, models.CreateDriveItemFromDiscriminatorValue,
    )
    if err != nil {
        panic(err)
    }

    if driveItem.GetSize() == nil {
        panic(fmt.Errorf("size is nil for driveItem %s", driveItemId))
    }
}
```